### PR TITLE
add filterTag to topic.subscribeP

### DIFF
--- a/ts/Topic.ts
+++ b/ts/Topic.ts
@@ -49,7 +49,7 @@ module AliMNS{
             return this._openStack.sendP("GET", url, null, headers);
         }
         
-        public subscribeP(name:string, endPoint:string, notifyStrategy?:string, notifyContentFormat?:string){
+        public subscribeP(name:string, endPoint:string, notifyStrategy?:string, notifyContentFormat?:string, filterTag?:string){
             var body = {
                 Subscription: {
                     Endpoint: endPoint
@@ -57,6 +57,7 @@ module AliMNS{
             };
             if(notifyStrategy) body.Subscription['NotifyStrategy'] = notifyStrategy;
             if(notifyContentFormat) body.Subscription['NotifyContentFormat'] = notifyContentFormat;
+            if(filterTag) body.Subscription.FilterTag = filterTag;
             var url = Url.resolve(this._urlSubscription, name);
             debug("PUT " + url, body);
             return this._openStack.sendP("PUT", url, body);


### PR DESCRIPTION
https://help.aliyun.com/document_detail/27496.html?spm=5176.doc27473.6.264.A8o1hm

FilterTag	描述了该订阅中消息过滤的标签（标签一致的消息才会被推送）	不超过16个字符的字符串，默认不进行消息过滤	Optional